### PR TITLE
Add deploy make target for CI deployment

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 # Copyright (c) 2019 true[X], Inc. All rights reserved.
 
-APPNAME = TruexRokuReferenceApp
+REFAPPNAME = TruexRokuReferenceApp
 IMPORTS =
 ROKU_TEST_ID = 1
 ROKU_TEST_WAIT_DURATION = 5
@@ -16,7 +16,7 @@ include $(APPSROOT)/app.mk
 # deploy `TruexRokuReferenceApp` side-load capable zip file to s3
 # append the major, minor then rc or develop components to the upload path.
 # Note: the MAJOR, MINOR, BUILD_NUM, BUILD_HASH env variables are set upstream by the Jenkins system (TAR's Jenkinsfile)
-deploy: $(APPNAME)
+deploy: $(REFAPPNAME)
 	S3_BUCKET=$$(grep s3_bucket ~/Library/Truex/Roku/target | sed 's/s3_bucket=//') ;\
 	echo $$S3_BUCKET ;\
 	echo $$MAJOR ;\
@@ -24,4 +24,4 @@ deploy: $(APPNAME)
 	echo $$BUILD_NUM ;\
 	echo $$BUILD_HASH ;\
 	sed -i "s/ComponentLibrary(\s*)id=\"TruexAdRendererLib\"(\s*)uri=\".*\"/ComponentLibrary(\s*)id=\"TruexAdRendererLib\"(\s*)uri=\"http://@{S3_BUCKET}roku/v${MAJOR}_${MINOR}/${RC_DEVELOP}/${APPNAME}-${RC_DEVELOP}-v${MAJOR}.${MINOR}.${BUILD_NUM}-${BUILD_HASH}.pkg"/g" components/MainScene.xml ;\
-	aws s3 cp dist/apps/${APPNAME}.zip s3://$$S3_BUCKET/roku/v${MAJOR}_${MINOR}/${RC_DEVELOP}/${APPNAME}-${RC_DEVELOP}-v${MAJOR}.${MINOR}.${BUILD_NUM}-${BUILD_HASH}.zip --acl public-read ;\
+	aws s3 cp dist/apps/${REFAPPNAME}.zip s3://$$S3_BUCKET/roku/v${MAJOR}_${MINOR}/${RC_DEVELOP}/${REFAPPNAME}-${RC_DEVELOP}-v${MAJOR}.${MINOR}.${BUILD_NUM}-${BUILD_HASH}.zip --acl public-read ;\


### PR DESCRIPTION
Updating makefile to support `deploy` target for our CI pipeline to publish builds.