### PR TITLE
CTV-2023: one stage updates for v1.2

### DIFF
--- a/components/ContentFlow.brs
+++ b/components/ContentFlow.brs
@@ -119,12 +119,14 @@ sub launchTruexAd()
 
     ? "TRUE[X] >>> ContentFlow::launchTruexAd() - starting ad at video position: ";m.videoPlayer.position
 
-    ' pause the stream, which is currently playing a video ad
-    ' m.videoPlayer.control = "pause"
     m.videoPositionAtAdBreakPause = m.videoPlayer.position
-    ' m.currentAdBreak = decodedData.currentAdBreak
     ' Note: bumping the seek interval as the Roku player seems to have trouble seeking ahead to a specific time based on the type of stream.
     m.streamSeekDuration = decodedData.cardDuration + 3
+    ' Populating the test ad from the local mock payload
+    ' In a real world situation, the adParameters returned from the ad server will be populated similarly 
+    ' for the One Stage type integration we're demonstrating here.
+    adPayload = ParseJson(ReadAsciiFile(decodedData.vastPayload).trim())
+    adPayload.placement_hash = decodedData.placementHash
 
     ? "TRUE[X] >>> ContentFlow::launchTruexAd() - instantiating TruexAdRenderer ComponentLibrary..."
 
@@ -135,11 +137,7 @@ sub launchTruexAd()
     ' use the companion ad data to initialize the true[X] renderer
     tarInitAction = {
         type: "init",
-        adParameters: {
-            vast_config_url: decodedData.vastUrl,
-            placement_hash: decodedData.placementHash
-        },
-        isOneStageIntegration: true,
+        adParameters: adPayload,
         supportsUserCancelStream: true, ' enables cancelStream event types, disable if Channel does not support
         slotType: UCase(getCurrentAdBreakSlotType()),
         logLevel: 1, ' Optional parameter, set the verbosity of true[X] logging, from 0 (mute) to 5 (verbose), defaults to 5

--- a/components/MainScene.xml
+++ b/components/MainScene.xml
@@ -24,7 +24,7 @@
         -->
         <ComponentLibrary
             id="TruexAdRendererLib"
-            uri="http://development.scratch.truex.com.s3.amazonaws.com/roku/simon/TruexLibraryOneStage.zip"/>
+            uri="http://ctv.truex.com/roku/v1_2/rc/TruexAdRenderer-Roku-v1.2.27-d43cc69.pkg"/>
 
         <!-- Used as parent layout for all Flow's. -->
         <Group

--- a/manifest
+++ b/manifest
@@ -3,8 +3,8 @@
 ##   Channel Details
 title=TAR-Roku-Reference
 major_version=1
-minor_version=0
-build_version=0000
+minor_version=2
+build_version=0001
 ui_resolutions=fhd
 supports_input_launch=1
 rsg_version=1.2

--- a/res/reference-app-streams.json
+++ b/res/reference-app-streams.json
@@ -11,7 +11,7 @@
                 "timeOffset" : "00:00:00.000",
                 "cardDuration" : "15",
                 "videoAdDuration" : "92",
-                "vastUrl" : "pkg:/res/demo-ad-payload.json",
+                "vastPayload" : "pkg:/res/demo-ad-payload.json",
                 "placementHash" : "74fca63c733f098340b0a70489035d683024440d"
             },
             {
@@ -19,7 +19,7 @@
                 "timeOffset" : "00:09:52.000",
                 "cardDuration" : "15",
                 "videoAdDuration" : "92",
-                "vastUrl" : "pkg:/res/demo-ad-payload-2.json",
+                "vastPayload" : "pkg:/res/demo-ad-payload-2.json",
                 "placementHash" : "74fca63c733f098340b0a70489035d683024440d"
             }
         ]


### PR DESCRIPTION
Updates to the Roku reference app to account for v1.2 TAR changes.

The key difference is the way the ad payload come in up front as the `adParameters` element (one stage integration), rather than being fetched via the `vast_config_url`.